### PR TITLE
Fixed Pre-Commit Hooks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,5 @@ import vercel from "@astrojs/vercel/serverless";
 // https://astro.build/config
 export default defineConfig({
   output: "server",
-  adapter: vercel()
+  adapter: vercel(),
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typescript": "5.0.3"
   },
   "lint-staged": {
-    "*.{astro,md}": [
+    "*.{astro,js}": [
       "prettier --write",
       "eslint --ext .js,.astro --fix"
     ]

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "typescript": "5.0.3"
   },
   "lint-staged": {
-    "*.{astro,js}": [
-      "prettier --write",
+    "*.{astro,js,ts}": [
       "eslint --ext .js,.astro --fix"
+    ],
+    "*": [
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
Closes #11 

#### Changes
- Split Prettier and ESLint pre-commit hooks.
- Run ESLint on `.astro`, `.js`, and `.ts` files only.
- Run Prettier on all files `*` (it only runs on supported file formats).
- Commited the prettified `astro.config.mjs`.